### PR TITLE
[Feat] 상품 상세 페이지 연결, 카카오페이 주문 기능 구현 (#50, #71) 

### DIFF
--- a/backend/src/main/java/com/example/backend/config/CustomAuthenticationProvider.java
+++ b/backend/src/main/java/com/example/backend/config/CustomAuthenticationProvider.java
@@ -1,6 +1,5 @@
 package com.example.backend.config;
 
-
 import com.example.backend.customer.model.entity.Customer;
 import com.example.backend.customer.service.CustomerService;
 import lombok.RequiredArgsConstructor;
@@ -19,16 +18,13 @@ public class CustomAuthenticationProvider implements AuthenticationProvider {
     private final CustomerService customerService;
     private final PasswordEncoder passwordEncoder;
 
-
     @Override
     public Authentication authenticate(Authentication authentication) throws AuthenticationException {
         String username = authentication.getName();
         String password = authentication.getCredentials().toString();
 
-
         UserDetails userDetails;
         userDetails = (Customer) customerService.loadUserByUsername(username);
-
 
         if (passwordEncoder.matches(password, userDetails.getPassword()) && userDetails.isEnabled()) {
             return new UsernamePasswordAuthenticationToken(userDetails, password, userDetails.getAuthorities());
@@ -40,5 +36,4 @@ public class CustomAuthenticationProvider implements AuthenticationProvider {
     public boolean supports(Class<?> authentication) {
         return authentication.equals(UsernamePasswordAuthenticationToken.class);
     }
-
 }

--- a/backend/src/main/java/com/example/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/backend/config/SecurityConfig.java
@@ -37,6 +37,7 @@ public class SecurityConfig{
                     .antMatchers("/qna/*").permitAll()
                     .antMatchers("/test/member").hasRole("MEMBER")
                     .antMatchers("/test/customer").hasRole("MEMBER")
+                    .antMatchers("/orders").permitAll()
                     .antMatchers("/**").permitAll()
                     .anyRequest().permitAll();
 

--- a/backend/src/main/java/com/example/backend/orders/controller/OrdersController.java
+++ b/backend/src/main/java/com/example/backend/orders/controller/OrdersController.java
@@ -20,12 +20,10 @@ public class OrdersController {
     @RequestMapping(method = RequestMethod.GET,value = "/validation")
     public ResponseEntity<GetOrdersCreateRes> ordersCreate(@RequestHeader(value = "Authorization") String token, String impUid) throws IamportResponseException, IOException {
             //TODO: 프론트 연결 후 유효성 검증 가능(주석 해제)
-//            if(paymentService.paymentValidation(impUid)){
-//                return ordersService.createOrder(token, impUid);
-//            }
-//            return null;
-
-        return ordersService.createOrder(token, impUid);
+            if(paymentService.paymentValidation(impUid)){
+                return ordersService.createOrder(token, impUid);
+            }
+            return null;
 
     }
 }

--- a/backend/src/main/java/com/example/backend/product/controller/ProductController.java
+++ b/backend/src/main/java/com/example/backend/product/controller/ProductController.java
@@ -24,8 +24,8 @@ public class ProductController {
         return ResponseEntity.ok().body(productService.list());
     }
 
-    @RequestMapping(method = RequestMethod.GET, value = "/read")
-    public ResponseEntity<GetProductRes> read(Long idx, Authentication authentication) {
+    @RequestMapping(method = RequestMethod.GET, value = "/read/{idx}")
+    public ResponseEntity<GetProductRes> read(@PathVariable Long idx, Authentication authentication) {
         return ResponseEntity.ok().body(productService.read(idx, authentication));
     }
 

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -13,5 +13,9 @@
     </noscript>
     <div id="app"></div>
     <!-- built files will be auto injected -->
+    <!-- jQuery -->
+    <script type="text/javascript" src="https://code.jquery.com/jquery-1.12.4.min.js" ></script>
+    <!-- iamport.payment.js -->
+    <script type="text/javascript" src="https://cdn.iamport.kr/js/iamport.payment-1.1.8.js"></script>
   </body>
 </html>

--- a/frontend/src/pages/LoginPage.vue
+++ b/frontend/src/pages/LoginPage.vue
@@ -35,7 +35,10 @@ export default {
       if (result && result.status !== false) {
         // status가 0이 아니면 로그인 성공 처리
         const customerIdx = sessionStorage.getItem('customerIdx');
+        const accessToken = sessionStorage.getItem('atoken');
+
         localStorage.setItem('customerIdx', customerIdx);
+        localStorage.setItem('accessToken', "Bearer " + accessToken);
 
         console.log(`로그인 성공: ${customerIdx}`);
 

--- a/frontend/src/pages/MainPage.vue
+++ b/frontend/src/pages/MainPage.vue
@@ -3,12 +3,12 @@
     <section v-for="(categorySlides, category) in categoriesWithSlides" :key="category">
       <div class="div" v-html="getCategoryName(category)"></div>
       <Carousel :itemsToShow="3.95" :wrapAround="true" :transition="500">
-        <Slide v-for="product in categorySlides" :key="product.idx" @click="goToProductDetail(product.idx)">
+        <Slide v-for="product in categorySlides" :key="product.idx">
           <div class="carousel__slide product">
             <div class="carousel__item-column">
-              <img :src="product.productImage" alt="Slide Image">
+              <img :src="product.productImage" alt="Slide Image" @click="goToProduct(product.idx)">
             </div>
-            <div class="carousel__item-column">
+            <div class="carousel__item-column" @click="goToProduct(product.idx)">
               <div class="carousel__item-details">
                 <div class="carousel__item-title">{{ product.productName }}</div>
                 <div class="carousel__item-price">{{ product.productPrice }}원</div>
@@ -33,12 +33,14 @@ import 'vue3-carousel/dist/carousel.css';
 
 export default defineComponent({
   name: 'CategoryCarousels',
+
   components: {
     Carousel,
     Slide,
     Pagination,
     Navigation
   },
+
   setup() {
     const categoriesWithSlides = ref({});
 
@@ -79,11 +81,18 @@ export default defineComponent({
 
     fetchCategorySlides();
 
+
     return {
       categoriesWithSlides,
       getCategoryName
     };
   },
+
+  methods: {
+    async goToProduct(idx) {
+      this.$router.push(`/product/${idx}`)
+    }
+  }
 });
 </script>
 

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -10,7 +10,7 @@ const routes = [
   // { path: "/", component: MainPage, beforeEnter: requireAuth() },
   { path: "/", component: MainPage  },
   { path: '/verify', component: VerifyPage },
-  {path: "/productDetails", component: DetailsComponent},
+  {path: "/product/:productIdx", component: DetailsComponent},
   { path: "/product", component: DetailsComponent },
   { path: "/login", component: LoginPage},
   { path: "/Signup", component: SignupPage},


### PR DESCRIPTION
- 메인 페이지에서 각 상품을 선택했을 때 해당 상품의 상세 페이지로 이동
- 주문하기 버튼을 눌렀을 때 카카오페이 QR코드가 나옴

- Iamport 라이브러리 추가
- 카카오페이 QR코드로 해당 상품을 결제
- localStorage에 토큰값 저장해서 백엔드 요청\

close #50, #71 