### PR TITLE
[Feat] 메인 대쉬보드 벡엔드 카테고리 별 판매량(#113), 월 별 매출 계산, 프론트엔드 axios 추가 (#117)

### DIFF
--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -28,7 +28,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true

--- a/backend_admin/src/main/java/com/example/backend_admin/calculate/controller/CalculateController.java
+++ b/backend_admin/src/main/java/com/example/backend_admin/calculate/controller/CalculateController.java
@@ -28,6 +28,18 @@ public class CalculateController {
     @RequestMapping("/today/orders")
     public GetTodayOrdersRes todayOrders(){return calculateOrdersService.todayOrders();}
 
+
+    @RequestMapping("/category/orders")
+    public GetCategoryOrdersRes categoryOrdersRes(){
+        return calculateOrdersService.categoryOrderRes();
+    }
+
+    @RequestMapping("/month/orders")
+    public GetCategoryOrdersRes monthOrdersRes(){
+        return calculateOrdersService.monthOrdersRes();
+    }
+
+
     @RequestMapping("/today/sleep")
     public GetSleepAccountGrowthRateRes sleepAccountGrowthRate(){
         return calculateLogService.sleepAccountGrowthRate();

--- a/backend_admin/src/main/java/com/example/backend_admin/calculate/model/response/GetCategoryOrdersRes.java
+++ b/backend_admin/src/main/java/com/example/backend_admin/calculate/model/response/GetCategoryOrdersRes.java
@@ -1,0 +1,10 @@
+package com.example.backend_admin.calculate.model.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GetCategoryOrdersRes {
+    int[] array;
+}

--- a/backend_admin/src/main/java/com/example/backend_admin/calculate/service/CalculateOrdersService.java
+++ b/backend_admin/src/main/java/com/example/backend_admin/calculate/service/CalculateOrdersService.java
@@ -1,27 +1,29 @@
 package com.example.backend_admin.calculate.service;
 
+import com.example.backend_admin.calculate.model.response.GetCategoryOrdersRes;
 import com.example.backend_admin.calculate.model.response.GetTodayOrdersRes;
+import com.example.backend_admin.orders.model.entity.Orders;
 import com.example.backend_admin.orders.repository.OrdersRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import com.example.backend_admin.product.repository.ProductRepository;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class CalculateOrdersService {
     private final OrdersRepository ordersRepository;
+    private final ProductRepository productRepository;
+    LocalDateTime today = LocalDateTime.now();
 
     public GetTodayOrdersRes todayOrders() {
-        LocalDateTime today = LocalDateTime.now();
-
         Integer todayOrdersCount = ordersRepository.countByCreatedDateAfter(today.minusDays(1));
         Integer fromYesterdayOrdersCount = ordersRepository.countByCreatedDateAfter(today.minusDays(2));
 
         Integer todayOrdersAmount = ordersRepository.sumProductPriceByCreatedDateAfter(today.minusDays(1));
         Integer fromYesterdayOrdersAmount = ordersRepository.sumProductPriceByCreatedDateAfter(today.minusDays(2));
-
-//        if(todayOrdersAmount == null) todayOrdersAmount = 0;
 
         return GetTodayOrdersRes.builder()
                 .todayOrdersCount(todayOrdersCount)
@@ -29,5 +31,31 @@ public class CalculateOrdersService {
                 .todayOrdersAmount(todayOrdersAmount)
                 .difOrdersAmount(2*todayOrdersAmount -fromYesterdayOrdersAmount)
                 .build();
+    }
+
+    public GetCategoryOrdersRes categoryOrderRes() {
+
+        List<Orders> ordersList = ordersRepository.findByCreatedDateAfter(today.minusDays(14));
+        int[] array = new int[6];
+
+        for(Orders orders : ordersList){
+            Long productIdx = orders.getProductIdx();
+            Integer category = productRepository.findById(productIdx).get().getCategory();
+            array[category] = orders.getProductPrice();
+        }
+
+        return GetCategoryOrdersRes.builder().array(array).build();
+    }
+
+    public GetCategoryOrdersRes monthOrdersRes() {
+        List<Orders> ordersList = ordersRepository.findByCreatedDateAfter(today.minusDays(365));
+        int[] array = new int[12];
+
+        for(Orders orders : ordersList){
+            Integer month = orders.getCreatedDate().getMonthValue();
+            array[month-1] = orders.getProductPrice();
+        }
+
+        return GetCategoryOrdersRes.builder().array(array).build();
     }
 }

--- a/backend_admin/src/main/java/com/example/backend_admin/orders/repository/OrdersRepository.java
+++ b/backend_admin/src/main/java/com/example/backend_admin/orders/repository/OrdersRepository.java
@@ -16,4 +16,6 @@ public interface OrdersRepository extends JpaRepository<Orders, Long> {
     Integer countByCreatedDateAfter(LocalDateTime createdDate);
     @Query("SELECT COALESCE(SUM(o.productPrice), 0) FROM Orders o WHERE o.createdDate > :createdDate")
     Integer sumProductPriceByCreatedDateAfter(@Param("createdDate") LocalDateTime createdDate);
+
+    List<Orders> findByCreatedDateAfter(LocalDateTime createDate);
 }

--- a/frontend/src/pages/SignupPage.vue
+++ b/frontend/src/pages/SignupPage.vue
@@ -89,7 +89,7 @@ export default {
     async signup() {
       let result = await this.customerStore.signup(this.customerSignup)
       if (result === true) {
-        window.location.href = "/customer/login";
+        window.location.href = "/login";
       } else {
         alert("회원 가입 실패");
         this.resetSignupForm();

--- a/frontend_admin/src/page/MainDashboard.vue
+++ b/frontend_admin/src/page/MainDashboard.vue
@@ -197,7 +197,7 @@
               <div class="card">
                 <div class="card-body"><div class="chartjs-size-monitor"><div class="chartjs-size-monitor-expand"><div class=""></div></div><div class="chartjs-size-monitor-shrink"><div class=""></div></div></div>
                   <h4 class="card-title">월별 매출 </h4>
-                  <canvas id="barChart" style="height: 180px; display: block; width: 320px;" width="358" height="180" class="chartjs-render-monitor"></canvas>
+                  <canvas ref="monthChart" id="barChart" style="height: 180px; display: block; width: 320px;" width="358" height="180" class="chartjs-render-monitor"></canvas>
                 </div>
               </div>
             </div>
@@ -291,12 +291,68 @@ export default {
         }
       },
 
+      barData: {
+        datasets: [{
+          data: [],
+          backgroundColor: [
+            'rgba(255, 99, 132, 0.5)',
+            'rgba(54, 162, 235, 0.5)',
+            'rgba(255, 206, 86, 0.5)',
+            'rgba(75, 192, 192, 0.5)',
+            'rgba(153, 102, 255, 0.5)',
+            'rgba(255, 159, 64, 0.5)',
+            'rgba(255, 99, 132, 0.5)',
+            'rgba(54, 162, 235, 0.5)',
+            'rgba(255, 206, 86, 0.5)',
+            'rgba(75, 192, 192, 0.5)',
+            'rgba(153, 102, 255, 0.5)',
+            'rgba(255, 159, 64, 0.5)'
+          ],
+          borderColor: [
+            'rgba(255,99,132,1)',
+            'rgba(54, 162, 235, 1)',
+            'rgba(255, 206, 86, 1)',
+            'rgba(75, 192, 192, 1)',
+            'rgba(153, 102, 255, 1)',
+            'rgba(255, 159, 64, 1)',
+            'rgba(255,99,132,1)',
+            'rgba(54, 162, 235, 1)',
+            'rgba(255, 206, 86, 1)',
+            'rgba(75, 192, 192, 1)',
+            'rgba(153, 102, 255, 1)',
+            'rgba(255, 159, 64, 1)'
+          ],
+        }],
+        // These labels appear in the legend and in the tooltips when hovering different arcs
+        labels: [
+          '1월',
+          '2월',
+          '3월',
+          '4월',
+          '5월',
+          '6월',
+          '7월',
+          '8월',
+          '9월',
+          '10월',
+          '11월',
+          '12월'
+        ]
+      }, options: {
+        responsive: true,
+        animation: {
+          animateScale: true,
+          animateRotate: true
+        }
+      },
       qnasWaitings: 0,
       qnasWaiting: []
 
 
     };
   },
+
+
   methods: {
     fetchVisitorCount() { //방문자 수
       axios.get('http://localhost:8000/today/login')
@@ -395,8 +451,7 @@ export default {
           .catch(error => console.error("방문자 수를 불러오는 데 실패했습니다.", error));
     },
 
-
-    createChart() {
+    createPieChart() {
       axios.get('http://localhost:8000/category/orders')
           .then(response => {
             const responseData = response.data;
@@ -416,6 +471,27 @@ export default {
           })
           .catch(error => console.error("카테고리별 판매율을 불러오는 데 실패했습니다.", error));
     },
+    createBarChart() {
+      axios.get('http://localhost:8000/month/orders')
+          .then(response => {
+            const responseData = response.data;
+            this.barData.datasets[0].data = responseData.array;
+            // 데이터 로딩이 완료된 후에 차트를 생성합니다.
+            this.$nextTick(() => {
+              // 차트 인스턴스가 이미 존재하는 경우, 이를 업데이트하거나 파괴 후 재생성해야 할 수도 있습니다.
+              if (this.chartInstance2) {
+                this.chartInstance2.destroy(); // 기존 차트 인스턴스를 파괴합니다.
+              }
+              this.chartInstance2 = new Chart(this.$refs.monthChart, {
+                type: 'bar',
+                data: this.barData,
+                options: this.options
+              });
+            });
+          })
+          .catch(error => console.error("월별 매출액을 불러오는 데 실패했습니다.", error));
+    },
+
     loadArticles() {
       axios.get("http://localhost:8000/admin/qna/list")
           .then((response) => {
@@ -444,8 +520,8 @@ export default {
 
     this.fetchqnalist();
 
-
-    this.createChart();
+    this.createPieChart();
+    this.createBarChart()
     this.loadArticles();
 
   }


### PR DESCRIPTION
- 회원가입 후 로그인 페이지로 리다이렉트 수정
- 카테고리 별 판매량, 월 별 매출 계산 기능 추가
-메인 대쉬보드 카테고리 별 판매량, 월 별 매출 계산 axios 추가